### PR TITLE
Fix strictness mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ simpleFoldCountFile s =
      in (cs, ws, ls)
   where
     go :: (Int, Int, Int, Bool) -> Char -> (Int, Int, Int, Bool)
-    go (!cs, !ws, !ls, !wasSpace) c =
+    go (cs, ws, ls, wasSpace) c =
         let addLine | c == '\n' = 1
                     | otherwise = 0
             addWord | wasSpace = 0


### PR DESCRIPTION
Bang patterns are only introduced in the text afterwards?