### PR TITLE
Update streamly version

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,8 @@ executables:
     - -rtsopts
     - -with-rtsopts=-N
     - -O2
+    - -fspec-constr-recursive=10
+
     dependencies:
     - wc
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,6 +42,8 @@ packages:
 
 extra-deps:
 - flux-monoid-0.1.0.0@sha256:c428dc47c6fcc52a3e5ce30ef4c97a2afccb3d2a0663bc4bd525f470ba6deb24,683
+- git: https://github.com/composewell/streamly.git
+  commit: 0e98baf0132ca19d783e6a65b24d4e866b6d587a
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Updated the streamly to the latest version on the master branch. The same code works for utf8/ascii/parallel-utf8/parallel-ascii. You just need to change the `UTF8` and `PARALLEL` CPP macros accordingly.

This code does not use explicit chunking of the file and therefore can work on streams like `stdin`.